### PR TITLE
Forking Solver (Z3)

### DIFF
--- a/include/klee/Expr/Constraints.h
+++ b/include/klee/Expr/Constraints.h
@@ -35,6 +35,7 @@ public:
   ConstraintSet() = default;
 
   void push_back(const ref<Expr> &e);
+  void pop_back();
 
   bool operator==(const ConstraintSet &b) const {
     return constraints == b.constraints;

--- a/include/klee/Solver/Solver.h
+++ b/include/klee/Solver/Solver.h
@@ -75,6 +75,12 @@ namespace klee {
     Solver(std::unique_ptr<SolverImpl> impl);
     virtual ~Solver();
 
+    virtual std::unique_ptr<Solver> fork() {
+      assert(false && "Fork not implemented!");
+    }
+
+    virtual 
+
     /// evaluate - Determine for a particular state if the query
     /// expression is provably true, provably false or neither.
     ///

--- a/include/klee/Solver/Solver.h
+++ b/include/klee/Solver/Solver.h
@@ -79,8 +79,6 @@ namespace klee {
       assert(false && "Fork not implemented!");
     }
 
-    virtual 
-
     /// evaluate - Determine for a particular state if the query
     /// expression is provably true, provably false or neither.
     ///

--- a/include/klee/Solver/SolverCmdLine.h
+++ b/include/klee/Solver/SolverCmdLine.h
@@ -38,6 +38,8 @@ extern llvm::cl::opt<bool> UseIndependentSolver;
 
 extern llvm::cl::opt<bool> DebugValidateSolver;
 
+extern llvm::cl::opt<bool> UseIncrementalSolver;
+
 extern llvm::cl::opt<std::string> MinQueryTimeToLog;
 
 extern llvm::cl::opt<bool> LogTimedOutQueries;

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -74,8 +74,8 @@ StackFrame::~StackFrame() {
 
 /***/
 
-ExecutionState::ExecutionState(KFunction *kf, MemoryManager *mm)
-    : pc(kf->instructions), prevPC(pc) {
+ExecutionState::ExecutionState(KFunction *kf, MemoryManager *mm, std::unique_ptr<TimingSolver> timingSolver)
+    : solver(std::move(timingSolver)),  pc(kf->instructions), prevPC(pc) {
   pushFrame(nullptr, kf);
   setID();
   if (mm->stackFactory && mm->heapFactory) {
@@ -93,6 +93,7 @@ ExecutionState::~ExecutionState() {
 }
 
 ExecutionState::ExecutionState(const ExecutionState& state):
+    solver(std::make_unique<TimingSolver>(state.solver->solver->fork(), state.solver->simplifyExprs)),
     pc(state.pc),
     prevPC(state.prevPC),
     stack(state.stack),

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -78,9 +78,6 @@ ExecutionState::ExecutionState(KFunction *kf, MemoryManager *mm)
     : pc(kf->instructions), prevPC(pc) {
   pushFrame(nullptr, kf);
   setID();
-
-  klee_warning("\t\t\tPush %d", (int) id);
-
   if (mm->stackFactory && mm->heapFactory) {
     stackAllocator = mm->stackFactory.makeAllocator();
     heapAllocator = mm->heapFactory.makeAllocator();
@@ -121,7 +118,6 @@ ExecutionState::ExecutionState(const ExecutionState& state):
     forkDisabled(state.forkDisabled),
     base_addrs(state.base_addrs),
     base_mos(state.base_mos) {
-  // klee_warning("\t\t\tCreating %d", id);
   for (const auto &cur_mergehandler: openMergeStack)
     cur_mergehandler->addOpenState(this);
 }
@@ -133,8 +129,6 @@ ExecutionState *ExecutionState::branch() {
   falseState->setID();
   falseState->coveredNew = false;
   falseState->coveredLines.clear();
-
-  klee_warning("\t\t\tCreating %d", falseState->id);
 
   return falseState;
 }

--- a/lib/Core/ExecutionState.cpp
+++ b/lib/Core/ExecutionState.cpp
@@ -78,6 +78,9 @@ ExecutionState::ExecutionState(KFunction *kf, MemoryManager *mm)
     : pc(kf->instructions), prevPC(pc) {
   pushFrame(nullptr, kf);
   setID();
+
+  klee_warning("\t\t\tPush %d", (int) id);
+
   if (mm->stackFactory && mm->heapFactory) {
     stackAllocator = mm->stackFactory.makeAllocator();
     heapAllocator = mm->heapFactory.makeAllocator();
@@ -118,6 +121,7 @@ ExecutionState::ExecutionState(const ExecutionState& state):
     forkDisabled(state.forkDisabled),
     base_addrs(state.base_addrs),
     base_mos(state.base_mos) {
+  // klee_warning("\t\t\tCreating %d", id);
   for (const auto &cur_mergehandler: openMergeStack)
     cur_mergehandler->addOpenState(this);
 }
@@ -129,6 +133,8 @@ ExecutionState *ExecutionState::branch() {
   falseState->setID();
   falseState->coveredNew = false;
   falseState->coveredLines.clear();
+
+  klee_warning("\t\t\tCreating %d", falseState->id);
 
   return falseState;
 }

--- a/lib/Core/ExecutionState.h
+++ b/lib/Core/ExecutionState.h
@@ -158,6 +158,8 @@ private:
 public:
   using stack_ty = std::vector<StackFrame>;
 
+  std::unique_ptr<TimingSolver> solver;
+
   // Execution - Control Flow specific
 
   /// @brief Pointer to instruction to be executed after the current
@@ -261,7 +263,7 @@ public:
   ExecutionState() = default;
 #endif
   // only to create the initial state
-  explicit ExecutionState(KFunction *kf, MemoryManager *mm);
+  explicit ExecutionState(KFunction *kf, MemoryManager *mm, std::unique_ptr<TimingSolver> timingSolver);
   // no copy assignment, use copy constructor
   ExecutionState &operator=(const ExecutionState &) = delete;
   // no move ctor

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4831,14 +4831,19 @@ bool Executor::getSymbolicSolution(const ExecutionState &state,
   // an example) While this process can be very expensive, it can
   // also make understanding individual test cases much easier.
   for (auto& pi: state.cexPreferences) {
-    klee_error("This is weird...");
-    assert(false);
-
     bool mustBeTrue;
     // Attempt to bound byte to constraints held in cexPreferences
+
+    // This solver invocation is very delicate. I am not sure whether it
+    // is fine to simply use the current incremental strategy (without even
+    // pushing). I'd have thought that this constraint set may be used in the
+    // future and so we should push/pop surrounding this, but if I leave it
+    // like this, surprisingly, the "previous constraint set being a prefix
+    // of the current one" error/assertion within `Z3Solver.cpp` is not hit.
     bool success =
       state.solver->mustBeTrue(extendedConstraints, Expr::createIsZero(pi),
-        mustBeTrue, state.queryMetaData); // TODO: Weird!
+        mustBeTrue, state.queryMetaData); 
+
     // If it isn't possible to add the condition without making the entire list
     // UNSAT, then just continue to the next condition
     if (!success) break;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1217,8 +1217,8 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       }
     }
 
-    addConstraint(*trueState, condition);
-    addConstraint(*falseState, Expr::createIsZero(condition));
+    addConstraint(*trueState, condition); // Add true condition to true state.
+    addConstraint(*falseState, Expr::createIsZero(condition)); // Add false condition to false state.
 
     // Kinda gross, do we even really still want this option?
     if (MaxDepth && MaxDepth<=trueState->depth) {
@@ -1227,7 +1227,7 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       return StatePair(nullptr, nullptr);
     }
 
-    return StatePair(trueState, falseState);
+    return StatePair(trueState, falseState); // Important.
   }
 }
 
@@ -1246,7 +1246,7 @@ void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
     for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
            siie = it->second.end(); siit != siie; ++siit) {
       bool res;
-      bool success = solver->mustBeFalse(state.constraints,
+      bool success = solver->mustBeFalse(state.constraints, // This may not be the current state! Issue.
                                          siit->assignment.evaluate(condition),
                                          res, state.queryMetaData);
       assert(success && "FIXME: Unhandled solver failure");

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -919,10 +919,8 @@ void Executor::branch(ExecutionState &state,
 
     // XXX do proper balance or keep random?
     result.push_back(&state);
-    // Note: we branch (N-1) times - original state is kept!
     for (unsigned i=1; i<N; ++i) {
       ExecutionState *es = result[theRNG.getInt32() % i];
-      // Here, branch is invoked.
       ExecutionState *ns = es->branch();
       addedStates.push_back(ns);
       result.push_back(ns);
@@ -1217,8 +1215,8 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       }
     }
 
-    addConstraint(*trueState, condition); // Add true condition to true state.
-    addConstraint(*falseState, Expr::createIsZero(condition)); // Add false condition to false state.
+    addConstraint(*trueState, condition);
+    addConstraint(*falseState, Expr::createIsZero(condition));
 
     // Kinda gross, do we even really still want this option?
     if (MaxDepth && MaxDepth<=trueState->depth) {
@@ -1227,7 +1225,7 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       return StatePair(nullptr, nullptr);
     }
 
-    return StatePair(trueState, falseState); // Important.
+    return StatePair(trueState, falseState);
   }
 }
 
@@ -1246,7 +1244,7 @@ void Executor::addConstraint(ExecutionState &state, ref<Expr> condition) {
     for (std::vector<SeedInfo>::iterator siit = it->second.begin(), 
            siie = it->second.end(); siit != siie; ++siit) {
       bool res;
-      bool success = solver->mustBeFalse(state.constraints, // This may not be the current state! Issue.
+      bool success = solver->mustBeFalse(state.constraints,
                                          siit->assignment.evaluate(condition),
                                          res, state.queryMetaData);
       assert(success && "FIXME: Unhandled solver failure");
@@ -3769,8 +3767,6 @@ void Executor::terminateState(ExecutionState &state,
   interpreterHandler->incPathsExplored();
   executionTree->setTerminationType(state, reason);
 
-  klee_warning("\t\t\tPop %d", state.id);
-
   std::vector<ExecutionState *>::iterator it =
       std::find(addedStates.begin(), addedStates.end(), &state);
   if (it==addedStates.end()) {
@@ -3787,8 +3783,6 @@ void Executor::terminateState(ExecutionState &state,
     executionTree->remove(state.executionTreeNode);
     delete &state;
   }
-
-  // klee_warning("Pop\t");
 }
 
 static bool shouldWriteTest(const ExecutionState &state) {
@@ -4725,8 +4719,6 @@ void Executor::runFunctionAsMain(Function *f,
 
   ExecutionState *state =
       new ExecutionState(kmodule->functionMap[f], memory.get());
-
-  klee_warning("Created initial state %d", (int) state->id);
 
   if (pathWriter) 
     state->pathOS = pathWriter->open();

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -919,8 +919,10 @@ void Executor::branch(ExecutionState &state,
 
     // XXX do proper balance or keep random?
     result.push_back(&state);
+    // Note: we branch (N-1) times - original state is kept!
     for (unsigned i=1; i<N; ++i) {
       ExecutionState *es = result[theRNG.getInt32() % i];
+      // Here, branch is invoked.
       ExecutionState *ns = es->branch();
       addedStates.push_back(ns);
       result.push_back(ns);
@@ -3767,6 +3769,8 @@ void Executor::terminateState(ExecutionState &state,
   interpreterHandler->incPathsExplored();
   executionTree->setTerminationType(state, reason);
 
+  klee_warning("\t\t\tPop %d", state.id);
+
   std::vector<ExecutionState *>::iterator it =
       std::find(addedStates.begin(), addedStates.end(), &state);
   if (it==addedStates.end()) {
@@ -3783,6 +3787,8 @@ void Executor::terminateState(ExecutionState &state,
     executionTree->remove(state.executionTreeNode);
     delete &state;
   }
+
+  // klee_warning("Pop\t");
 }
 
 static bool shouldWriteTest(const ExecutionState &state) {
@@ -4719,6 +4725,8 @@ void Executor::runFunctionAsMain(Function *f,
 
   ExecutionState *state =
       new ExecutionState(kmodule->functionMap[f], memory.get());
+
+  klee_warning("Created initial state %d", (int) state->id);
 
   if (pathWriter) 
     state->pathOS = pathWriter->open();

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -109,7 +109,6 @@ private:
   Searcher *searcher;
 
   ExternalDispatcher *externalDispatcher;
-  std::unique_ptr<TimingSolver> solver;
   std::unique_ptr<MemoryManager> memory;
   std::set<ExecutionState*, ExecutionStateIDCompare> states;
   StatsTracker *statsTracker;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -98,7 +98,7 @@ class Executor : public Interpreter {
   friend klee::Searcher *klee::constructUserSearcher(Executor &executor);
 
 public:
-  typedef std::pair<ExecutionState*,ExecutionState*> StatePair;
+  typedef std::pair<ExecutionState*,ExecutionState*> StatePair; // Returns a pair of states!
 
   /// The random number generator.
   RNG theRNG;

--- a/lib/Core/Executor.h
+++ b/lib/Core/Executor.h
@@ -98,7 +98,7 @@ class Executor : public Interpreter {
   friend klee::Searcher *klee::constructUserSearcher(Executor &executor);
 
 public:
-  typedef std::pair<ExecutionState*,ExecutionState*> StatePair; // Returns a pair of states!
+  typedef std::pair<ExecutionState*,ExecutionState*> StatePair;
 
   /// The random number generator.
   RNG theRNG;

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -406,7 +406,7 @@ void SpecialFunctionHandler::handleMemalign(ExecutionState &state,
   }
 
   std::pair<ref<Expr>, ref<Expr>> alignmentRangeExpr =
-      executor.solver->getRange(state.constraints, arguments[0],
+      state.solver->getRange(state.constraints, arguments[0],
                                 state.queryMetaData);
   ref<Expr> alignmentExpr = alignmentRangeExpr.first;
   auto alignmentConstExpr = dyn_cast<ConstantExpr>(alignmentExpr);
@@ -477,7 +477,7 @@ void SpecialFunctionHandler::handleAssume(ExecutionState &state,
     e = NeExpr::create(e, ConstantExpr::create(0, e->getWidth()));
   
   bool res;
-  bool success __attribute__((unused)) = executor.solver->mustBeFalse(
+  bool success __attribute__((unused)) = state.solver->mustBeFalse(
       state.constraints, e, res, state.queryMetaData);
   assert(success && "FIXME: Unhandled solver failure");
   if (res) {
@@ -580,11 +580,11 @@ void SpecialFunctionHandler::handlePrintRange(ExecutionState &state,
   if (!isa<ConstantExpr>(arguments[1])) {
     // FIXME: Pull into a unique value method?
     ref<ConstantExpr> value;
-    bool success __attribute__((unused)) = executor.solver->getValue(
+    bool success __attribute__((unused)) = state.solver->getValue(
         state.constraints, arguments[1], value, state.queryMetaData);
     assert(success && "FIXME: Unhandled solver failure");
     bool res;
-    success = executor.solver->mustBeTrue(state.constraints,
+    success = state.solver->mustBeTrue(state.constraints,
                                           EqExpr::create(arguments[1], value),
                                           res, state.queryMetaData);
     assert(success && "FIXME: Unhandled solver failure");
@@ -592,7 +592,7 @@ void SpecialFunctionHandler::handlePrintRange(ExecutionState &state,
       llvm::errs() << " == " << value;
     } else { 
       llvm::errs() << " ~= " << value;
-      std::pair<ref<Expr>, ref<Expr>> res = executor.solver->getRange(
+      std::pair<ref<Expr>, ref<Expr>> res = state.solver->getRange(
           state.constraints, arguments[1], state.queryMetaData);
       llvm::errs() << " (in [" << res.first << ", " << res.second <<"])";
     }
@@ -808,7 +808,7 @@ void SpecialFunctionHandler::handleMakeSymbolic(ExecutionState &state,
 
     // FIXME: Type coercion should be done consistently somewhere.
     bool res;
-    bool success __attribute__((unused)) = executor.solver->mustBeTrue(
+    bool success __attribute__((unused)) = s->solver->mustBeTrue(
         s->constraints,
         EqExpr::create(
             ZExtExpr::create(arguments[1], Context::get().getPointerWidth()),

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -176,3 +176,5 @@ klee::ConstraintSet::constraint_iterator ConstraintSet::end() const {
 size_t ConstraintSet::size() const noexcept { return constraints.size(); }
 
 void ConstraintSet::push_back(const ref<Expr> &e) { constraints.push_back(e); }
+
+void ConstraintSet::pop_back() { constraints.pop_back(); }

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -388,13 +388,14 @@ bool STPSolverImpl::computeInitialValues(
   runStatusCode = SOLVER_RUN_STATUS_FAILURE;
   TimerStatIncrementer t(stats::queryTime);
 
+  // TODO: Reduce duplication with Z3SolverImpl::internalRunSolver.
   auto stack_it = assertionStack.begin();
   auto query_it = query.constraints.begin();
   // LCP between the assertion stack and the query constraints.
   while (stack_it != assertionStack.end() && query_it != query.constraints.end() && !(*stack_it)->compare(*(*query_it))) {
     ++stack_it;
     ++query_it;
-    klee_warning("Equal constraint found!");
+    klee_warning("Equal constraint found!"); // TODO: Remove this.
   }
   // Pop off extra constraints from stack.
   size_t pops = std::distance(stack_it, assertionStack.end());

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -17,6 +17,7 @@
 #include "klee/Expr/Constraints.h"
 #include "klee/Expr/ExprUtil.h"
 #include "klee/Solver/SolverImpl.h"
+#include "klee/Solver/SolverCmdLine.h"
 #include "klee/Support/ErrorHandling.h"
 #include "klee/Support/OptionCategories.h"
 
@@ -91,6 +92,10 @@ private:
   bool useForkedSTP;
   SolverRunStatus runStatusCode;
   ConstraintSet assertionStack;
+
+  bool computeInitialValuesIncremental(
+      const Query &query, const std::vector<const Array *> &objects,
+      std::vector<std::vector<unsigned char>> &values, bool &hasSolution);
 
 public:
   explicit STPSolverImpl(bool useForkedSTP, bool optimizeDivides = true);
@@ -383,6 +388,54 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
 }
 
 bool STPSolverImpl::computeInitialValues(
+    const Query &query, const std::vector<const Array *> &objects,
+    std::vector<std::vector<unsigned char>> &values, bool &hasSolution) {
+  if (UseIncrementalSolver) {
+    return computeInitialValuesIncremental(query, objects, values, hasSolution);
+  }
+
+  runStatusCode = SOLVER_RUN_STATUS_FAILURE;
+  TimerStatIncrementer t(stats::queryTime);
+
+  vc_push(vc);
+
+  for (const auto &constraint : query.constraints)
+    vc_assertFormula(vc, builder->construct(constraint));
+
+  ++stats::solverQueries;
+  ++stats::queryCounterexamples;
+  ExprHandle stp_e = builder->construct(query.expr);
+  if (DebugDumpSTPQueries) {
+    char *buf;
+    unsigned long len;
+    vc_printQueryStateToBuffer(vc, stp_e, &buf, &len, false);
+    klee_warning("STP query:\n%.*s\n", (unsigned)len, buf);
+    free(buf);
+  }
+  bool success;
+  if (useForkedSTP) {
+    runStatusCode = runAndGetCexForked(vc, builder.get(), stp_e, objects,
+                                       values, hasSolution, timeout);
+    success = ((SOLVER_RUN_STATUS_SUCCESS_SOLVABLE == runStatusCode) ||
+               (SOLVER_RUN_STATUS_SUCCESS_UNSOLVABLE == runStatusCode));
+  } else {
+    runStatusCode =
+        runAndGetCex(vc, builder.get(), stp_e, objects, values, hasSolution);
+    success = true;
+  }
+  if (success) {
+    if (hasSolution)
+      ++stats::queriesInvalid;
+    else
+      ++stats::queriesValid;
+  }
+
+  vc_pop(vc);
+
+  return success;
+}
+
+bool STPSolverImpl::computeInitialValuesIncremental(
     const Query &query, const std::vector<const Array *> &objects,
     std::vector<std::vector<unsigned char>> &values, bool &hasSolution) {
   runStatusCode = SOLVER_RUN_STATUS_FAILURE;

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -448,7 +448,6 @@ bool STPSolverImpl::computeInitialValuesIncremental(
   while (stack_it != assertionStack.end() && query_it != query.constraints.end() && !(*stack_it)->compare(*(*query_it))) {
     ++stack_it;
     ++query_it;
-    klee_warning("Equal constraint found!"); // TODO: Remove this.
   }
   // Pop off extra constraints from stack.
   size_t pops = std::distance(stack_it, assertionStack.end());

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -29,7 +29,6 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/wait.h>
-#include <vector>
 #include <unistd.h>
 
 namespace {
@@ -197,10 +196,9 @@ STPSolverImpl::~STPSolverImpl() {
 
 /***/
 
+// TODO: Should this be incremental?
 std::string STPSolverImpl::getConstraintLog(const Query &query) {
   vc_push(vc);
-
-  klee_warning("Constraint being logged!");
 
   for (const auto &constraint : query.constraints)
     vc_assertFormula(vc, builder->construct(constraint));

--- a/lib/Solver/SolverCmdLine.cpp
+++ b/lib/Solver/SolverCmdLine.cpp
@@ -62,6 +62,11 @@ cl::opt<bool> DebugValidateSolver(
              "with the results of the core solver (default=false)"),
     cl::cat(SolvingCat));
 
+cl::opt<bool> UseIncrementalSolver(
+    "use-incremental", cl::init(false),
+    cl::desc("Use incremental solving (default=false)"),
+    cl::cat(SolvingCat));
+
 cl::opt<std::string> MinQueryTimeToLog(
     "min-query-time-to-log",
     cl::desc("Set time threshold for queries logged in files. "

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -109,7 +109,6 @@ Z3SolverImpl::Z3SolverImpl()
               ? Z3LogInteractionFile.c_str()
               : NULL)),
       runStatusCode(SOLVER_RUN_STATUS_FAILURE) {
-  assert(false && "Z3 not implemented");
   assert(builder && "unable to create Z3Builder");
   solverParameters = Z3_mk_params(builder->ctx);
   Z3_params_inc_ref(builder->ctx, solverParameters);

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -354,7 +354,6 @@ bool Z3SolverImpl::internalRunSolverIncremental(
   while (stack_it != assertionStack.end() && query_it != query.constraints.end() && !(*stack_it)->compare(*(*query_it))) {
     ++stack_it;
     ++query_it;
-    klee_warning("Equal constraint found!"); // TODO: Remove this.
   }
   // Pop off extra constraints from stack.
   size_t pops = std::distance(stack_it, assertionStack.end());

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -59,6 +59,7 @@ namespace klee {
 
 class Z3SolverImpl : public SolverImpl {
 private:
+  ConstraintSet assertionStack;
   Z3_solver z3Solver;
   std::unique_ptr<Z3Builder> builder;
   time::Span timeout;
@@ -247,24 +248,60 @@ bool Z3SolverImpl::computeInitialValues(
 bool Z3SolverImpl::internalRunSolver(
     const Query &query, const std::vector<const Array *> *objects,
     std::vector<std::vector<unsigned char> > *values, bool &hasSolution) {
-  Z3_solver_push(builder->ctx, z3Solver);
-
-  TimerStatIncrementer t(stats::queryTime);
   runStatusCode = SOLVER_RUN_STATUS_FAILURE;
+  TimerStatIncrementer t(stats::queryTime);
 
-  ConstantArrayFinder constant_arrays_in_query;
-  for (auto const &constraint : query.constraints) {
-    Z3_solver_assert(builder->ctx, z3Solver, builder->construct(constraint));
-    constant_arrays_in_query.visit(constraint);
+  // TODO: Reduce duplication with STPSolverImpl::computeInitialValues.
+  auto stack_it = assertionStack.begin();
+  auto query_it = query.constraints.begin();
+  // LCP between the assertion stack and the query constraints.
+  while (stack_it != assertionStack.end() && query_it != query.constraints.end() && !(*stack_it)->compare(*(*query_it))) {
+    ++stack_it;
+    ++query_it;
+    klee_warning("Equal constraint found!"); // TODO: Remove this.
   }
+  // Pop off extra constraints from stack.
+  size_t pops = std::distance(stack_it, assertionStack.end());
+  for (size_t i = 0; i < pops; ++i) {
+    Z3_solver_pop(builder->ctx, z3Solver, 1);
+    assertionStack.pop_back();
+  }
+  // Add the remaining query constraints.
+  while (query_it != query.constraints.end()) {
+    Z3_solver_push(builder->ctx, z3Solver);
+    assertionStack.push_back(*query_it);
+    Z3_solver_assert(builder->ctx, z3Solver, builder->construct(*query_it));
+
+    ConstantArrayFinder constant_arrays_in_query;
+    constant_arrays_in_query.visit(*query_it);
+    // Add constant array assertions, NB: at the same level, to benefit from
+    // incrementality over them. Downside is that we may assert the same
+    // constraint multiple times.
+    for (auto const &constant_array : constant_arrays_in_query.results) {
+      assert(builder->constant_array_assertions.count(constant_array) == 1 &&
+              "Constant array found in query, but not handled by Z3Builder");
+      for (auto const &arrayIndexValueExpr :
+            builder->constant_array_assertions[constant_array]) {
+        Z3_solver_assert(builder->ctx, z3Solver, arrayIndexValueExpr);
+      }
+    }
+
+    ++query_it;
+  }
+
   ++stats::solverQueries;
   if (objects)
     ++stats::queryCounterexamples;
 
+  // We don't persist the negation of the query expression to the assertion stack;
+  // it is unintuitive that negation would aid future constraint sets.
+  // Push a level for constraints related to the query expression:
+  Z3_solver_push(builder->ctx, z3Solver);
   Z3ASTHandle z3QueryExpr =
       Z3ASTHandle(builder->construct(query.expr), builder->ctx);
-  constant_arrays_in_query.visit(query.expr);
 
+  ConstantArrayFinder constant_arrays_in_query;
+  constant_arrays_in_query.visit(query.expr);
   for (auto const &constant_array : constant_arrays_in_query.results) {
     assert(builder->constant_array_assertions.count(constant_array) == 1 &&
            "Constant array found in query, but not handled by Z3Builder");
@@ -302,6 +339,8 @@ bool Z3SolverImpl::internalRunSolver(
   // ``Query`` rather than only sharing within a single call to
   // ``builder->construct()``.
   builder->clearConstructCache();
+
+  // Pop the level relating to the query expression:
   Z3_solver_pop(builder->ctx, z3Solver, 1);
 
   if (runStatusCode == SolverImpl::SOLVER_RUN_STATUS_SUCCESS_SOLVABLE ||

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -109,6 +109,7 @@ Z3SolverImpl::Z3SolverImpl()
               ? Z3LogInteractionFile.c_str()
               : NULL)),
       runStatusCode(SOLVER_RUN_STATUS_FAILURE) {
+  assert(false && "Z3 not implemented");
   assert(builder && "unable to create Z3Builder");
   solverParameters = Z3_mk_params(builder->ctx);
   Z3_params_inc_ref(builder->ctx, solverParameters);

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -59,6 +59,7 @@ namespace klee {
 
 class Z3SolverImpl : public SolverImpl {
 private:
+  Z3_solver z3Solver;
   std::unique_ptr<Z3Builder> builder;
   time::Span timeout;
   SolverRunStatus runStatusCode;
@@ -113,7 +114,7 @@ Z3SolverImpl::Z3SolverImpl()
   solverParameters = Z3_mk_params(builder->ctx);
   Z3_params_inc_ref(builder->ctx, solverParameters);
   timeoutParamStrSymbol = Z3_mk_string_symbol(builder->ctx, "timeout");
-  setCoreSolverTimeout(timeout);
+  setCoreSolverTimeout(timeout); // TODO: Set incremental solver timeout?
 
   if (!Z3QueryDumpFile.empty()) {
     std::string error;
@@ -133,9 +134,14 @@ Z3SolverImpl::Z3SolverImpl()
     ss.flush();
     Z3_global_param_set("verbose", underlyingString.c_str());
   }
+
+  z3Solver = Z3_mk_solver(builder->ctx);
+  Z3_solver_inc_ref(builder->ctx, z3Solver);
+  Z3_solver_set_params(builder->ctx, z3Solver, solverParameters);
 }
 
 Z3SolverImpl::~Z3SolverImpl() {
+  Z3_solver_dec_ref(builder->ctx, z3Solver);
   Z3_params_dec_ref(builder->ctx, solverParameters);
 }
 
@@ -241,23 +247,14 @@ bool Z3SolverImpl::computeInitialValues(
 bool Z3SolverImpl::internalRunSolver(
     const Query &query, const std::vector<const Array *> *objects,
     std::vector<std::vector<unsigned char> > *values, bool &hasSolution) {
+  Z3_solver_push(builder->ctx, z3Solver);
 
   TimerStatIncrementer t(stats::queryTime);
-  // NOTE: Z3 will switch to using a slower solver internally if push/pop are
-  // used so for now it is likely that creating a new solver each time is the
-  // right way to go until Z3 changes its behaviour.
-  //
-  // TODO: Investigate using a custom tactic as described in
-  // https://github.com/klee/klee/issues/653
-  Z3_solver theSolver = Z3_mk_solver(builder->ctx);
-  Z3_solver_inc_ref(builder->ctx, theSolver);
-  Z3_solver_set_params(builder->ctx, theSolver, solverParameters);
-
   runStatusCode = SOLVER_RUN_STATUS_FAILURE;
 
   ConstantArrayFinder constant_arrays_in_query;
   for (auto const &constraint : query.constraints) {
-    Z3_solver_assert(builder->ctx, theSolver, builder->construct(constraint));
+    Z3_solver_assert(builder->ctx, z3Solver, builder->construct(constraint));
     constant_arrays_in_query.visit(constraint);
   }
   ++stats::solverQueries;
@@ -273,7 +270,7 @@ bool Z3SolverImpl::internalRunSolver(
            "Constant array found in query, but not handled by Z3Builder");
     for (auto const &arrayIndexValueExpr :
          builder->constant_array_assertions[constant_array]) {
-      Z3_solver_assert(builder->ctx, theSolver, arrayIndexValueExpr);
+      Z3_solver_assert(builder->ctx, z3Solver, arrayIndexValueExpr);
     }
   }
 
@@ -283,29 +280,29 @@ bool Z3SolverImpl::internalRunSolver(
   // negation of the equivalent i.e.
   // ∃ X Constraints(X) ∧ ¬ query(X)
   Z3_solver_assert(
-      builder->ctx, theSolver,
+      builder->ctx, z3Solver,
       Z3ASTHandle(Z3_mk_not(builder->ctx, z3QueryExpr), builder->ctx));
 
   if (dumpedQueriesFile) {
     *dumpedQueriesFile << "; start Z3 query\n";
-    *dumpedQueriesFile << Z3_solver_to_string(builder->ctx, theSolver);
+    *dumpedQueriesFile << Z3_solver_to_string(builder->ctx, z3Solver);
     *dumpedQueriesFile << "(check-sat)\n";
     *dumpedQueriesFile << "(reset)\n";
     *dumpedQueriesFile << "; end Z3 query\n\n";
     dumpedQueriesFile->flush();
   }
 
-  ::Z3_lbool satisfiable = Z3_solver_check(builder->ctx, theSolver);
-  runStatusCode = handleSolverResponse(theSolver, satisfiable, objects, values,
+  ::Z3_lbool satisfiable = Z3_solver_check(builder->ctx, z3Solver);
+  runStatusCode = handleSolverResponse(z3Solver, satisfiable, objects, values,
                                        hasSolution);
 
-  Z3_solver_dec_ref(builder->ctx, theSolver);
   // Clear the builder's cache to prevent memory usage exploding.
   // By using ``autoClearConstructCache=false`` and clearning now
   // we allow Z3_ast expressions to be shared from an entire
   // ``Query`` rather than only sharing within a single call to
   // ``builder->construct()``.
   builder->clearConstructCache();
+  Z3_solver_pop(builder->ctx, z3Solver, 1);
 
   if (runStatusCode == SolverImpl::SOLVER_RUN_STATUS_SUCCESS_SOLVABLE ||
       runStatusCode == SolverImpl::SOLVER_RUN_STATUS_SUCCESS_UNSOLVABLE) {

--- a/lib/Solver/Z3Solver.h
+++ b/lib/Solver/Z3Solver.h
@@ -12,6 +12,7 @@
 #define KLEE_Z3SOLVER_H
 
 #include "klee/Solver/Solver.h"
+#include <z3.h>
 
 namespace klee {
 /// Z3Solver - A complete solver based on Z3
@@ -19,6 +20,7 @@ class Z3Solver : public Solver {
 public:
   /// Z3Solver - Construct a new Z3Solver.
   Z3Solver();
+  Z3Solver(std::unique_ptr<SolverImpl> impl);
 
   /// Get the query in SMT-LIBv2 format.
   /// \return A C-style string. The caller is responsible for freeing this.
@@ -28,6 +30,8 @@ public:
   /// value; 0
   /// is off.
   virtual void setCoreSolverTimeout(time::Span timeout);
+
+  std::unique_ptr<Solver> fork() override;
 };
 }
 


### PR DESCRIPTION
## Summary

Forking Z3 solver's internal state using `translate`, maintaining a `Z3Solver` in each `ExecutionState`.

## Tasks

- [ ] Diagnose memory consumption
- [ ] Propose fixes to memory consumption (e.g. maintain a fixed pool of solvers instead)
- [ ] Think about `push`/`pop` issue that may discard all incremental learning
- [ ] Prefer `ConstraintSet` copy constructor

## Issues / Notes 

- To get the current implementation to work, we **must** disable `--rewrite-equalities` due to the prefix assertion failing.
- Memory usage is high! (As one would expect) The memory cap is hit on every benchmark within a couple of seconds. 