### PR TITLE
Stack-Basic (Assert)

### DIFF
--- a/include/klee/Solver/Solver.h
+++ b/include/klee/Solver/Solver.h
@@ -75,6 +75,14 @@ namespace klee {
     Solver(std::unique_ptr<SolverImpl> impl);
     virtual ~Solver();
 
+    virtual void push() {
+      assert(false && "Push not implemented for this solver");
+    }
+
+    virtual void pop() {
+      assert(false && "Pop not implemented for this solver");
+    }
+
     /// evaluate - Determine for a particular state if the query
     /// expression is provably true, provably false or neither.
     ///

--- a/include/klee/Solver/SolverCmdLine.h
+++ b/include/klee/Solver/SolverCmdLine.h
@@ -38,6 +38,8 @@ extern llvm::cl::opt<bool> UseIndependentSolver;
 
 extern llvm::cl::opt<bool> DebugValidateSolver;
 
+extern llvm::cl::opt<bool> UseIncrementalSolver;
+
 extern llvm::cl::opt<std::string> MinQueryTimeToLog;
 
 extern llvm::cl::opt<bool> LogTimedOutQueries;

--- a/include/klee/Solver/SolverCmdLine.h
+++ b/include/klee/Solver/SolverCmdLine.h
@@ -40,6 +40,8 @@ extern llvm::cl::opt<bool> DebugValidateSolver;
 
 extern llvm::cl::opt<bool> UseIncrementalSolver;
 
+extern llvm::cl::opt<bool> Verbose;
+
 extern llvm::cl::opt<std::string> MinQueryTimeToLog;
 
 extern llvm::cl::opt<bool> LogTimedOutQueries;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -926,7 +926,9 @@ void Executor::branch(ExecutionState &state,
       if (Verbose) {
         klee_warning("Push! - branch");
       }
-      solver->solver->push();
+      if (UseIncrementalSolver) { 
+        solver->solver->push();
+      }
       result.push_back(ns);
       executionTree->attach(es->executionTreeNode, ns, es, reason);
     }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1197,7 +1197,9 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       }
     }
 
-    solver->solver->push(); // TODO: should really change this so timer can time it!
+    if (UseIncrementalSolver) {
+      solver->solver->push(); // TODO: should really change this so timer can time it!
+    }
 
     klee_warning("Push! - fork");
     executionTree->attach(current.executionTreeNode, falseState, trueState, reason);
@@ -3769,7 +3771,10 @@ void Executor::terminateState(ExecutionState &state,
                       "replay did not consume all objects in test input.");
   }
 
-  solver->solver->pop(); // TODO: Should change - see push comment.
+  if (UseIncrementalSolver) {
+    solver->solver->pop(); // TODO: Should change - see push comment.
+  }
+
   klee_warning("Pop - terminate %d", state.getID());
 
   interpreterHandler->incPathsExplored();
@@ -4728,7 +4733,10 @@ void Executor::runFunctionAsMain(Function *f,
   ExecutionState *state =
       new ExecutionState(kmodule->functionMap[f], memory.get());
 
-  solver->solver->push();
+  if (UseIncrementalSolver) {
+    solver->solver->push();
+  }
+  
   klee_warning("Starting state %d", state->getID());
 
   if (pathWriter) 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -923,6 +923,8 @@ void Executor::branch(ExecutionState &state,
       ExecutionState *es = result[theRNG.getInt32() % i];
       ExecutionState *ns = es->branch();
       addedStates.push_back(ns);
+      klee_warning("Push! - branch");
+      klee_error("Branch reached - here!");
       result.push_back(ns);
       executionTree->attach(es->executionTreeNode, ns, es, reason);
     }
@@ -1195,6 +1197,9 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       }
     }
 
+    solver->solver->push(); // TODO: should really change this so timer can time it!
+
+    klee_warning("Push! - fork");
     executionTree->attach(current.executionTreeNode, falseState, trueState, reason);
     stats::incBranchStat(reason, 1);
 
@@ -3764,6 +3769,9 @@ void Executor::terminateState(ExecutionState &state,
                       "replay did not consume all objects in test input.");
   }
 
+  solver->solver->pop(); // TODO: Should change - see push comment.
+  klee_warning("Pop - terminate %d", state.getID());
+
   interpreterHandler->incPathsExplored();
   executionTree->setTerminationType(state, reason);
 
@@ -4719,6 +4727,9 @@ void Executor::runFunctionAsMain(Function *f,
 
   ExecutionState *state =
       new ExecutionState(kmodule->functionMap[f], memory.get());
+
+  solver->solver->push();
+  klee_warning("Starting state %d", state->getID());
 
   if (pathWriter) 
     state->pathOS = pathWriter->open();

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -923,8 +923,10 @@ void Executor::branch(ExecutionState &state,
       ExecutionState *es = result[theRNG.getInt32() % i];
       ExecutionState *ns = es->branch();
       addedStates.push_back(ns);
-      klee_warning("Push! - branch");
-      klee_error("Branch reached - here!");
+      if (Verbose) {
+        klee_warning("Push! - branch");
+        klee_error("Branch reached - here!");
+      }
       result.push_back(ns);
       executionTree->attach(es->executionTreeNode, ns, es, reason);
     }
@@ -1201,7 +1203,10 @@ Executor::StatePair Executor::fork(ExecutionState &current, ref<Expr> condition,
       solver->solver->push(); // TODO: should really change this so timer can time it!
     }
 
-    klee_warning("Push! - fork");
+    if (Verbose) {
+      klee_warning("Push! - fork");
+    }
+
     executionTree->attach(current.executionTreeNode, falseState, trueState, reason);
     stats::incBranchStat(reason, 1);
 
@@ -3775,7 +3780,9 @@ void Executor::terminateState(ExecutionState &state,
     solver->solver->pop(); // TODO: Should change - see push comment.
   }
 
-  klee_warning("Pop - terminate %d", state.getID());
+  if (Verbose) {
+    klee_warning("Pop - terminate %d", state.getID());
+  }
 
   interpreterHandler->incPathsExplored();
   executionTree->setTerminationType(state, reason);

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -925,8 +925,8 @@ void Executor::branch(ExecutionState &state,
       addedStates.push_back(ns);
       if (Verbose) {
         klee_warning("Push! - branch");
-        klee_error("Branch reached - here!");
       }
+      solver->solver->push();
       result.push_back(ns);
       executionTree->attach(es->executionTreeNode, ns, es, reason);
     }
@@ -4743,8 +4743,10 @@ void Executor::runFunctionAsMain(Function *f,
   if (UseIncrementalSolver) {
     solver->solver->push();
   }
-  
-  klee_warning("Starting state %d", state->getID());
+
+  if (Verbose) {
+    klee_warning("Starting state %d", state->getID());
+  }
 
   if (pathWriter) 
     state->pathOS = pathWriter->open();

--- a/lib/Solver/STPSolver.cpp
+++ b/lib/Solver/STPSolver.cpp
@@ -93,6 +93,10 @@ private:
   SolverRunStatus runStatusCode;
   std::vector<ConstraintSet> assertionStack;
 
+  bool computeInitialValuesIncremental(
+      const Query &query, const std::vector<const Array *> &objects,
+      std::vector<std::vector<unsigned char>> &values, bool &hasSolution);
+
 public:
   explicit STPSolverImpl(bool useForkedSTP, bool optimizeDivides = true);
   ~STPSolverImpl() override;
@@ -388,12 +392,60 @@ runAndGetCexForked(::VC vc, STPBuilder *builder, ::VCExpr q,
 bool STPSolverImpl::computeInitialValues(
     const Query &query, const std::vector<const Array *> &objects,
     std::vector<std::vector<unsigned char>> &values, bool &hasSolution) {
+  if (UseIncrementalSolver) {
+    return computeInitialValuesIncremental(query, objects, values, hasSolution);
+  }
+
+  runStatusCode = SOLVER_RUN_STATUS_FAILURE;
+  TimerStatIncrementer t(stats::queryTime);
+
+  vc_push(vc);
+  for (const auto &constraint : query.constraints)
+    vc_assertFormula(vc, builder->construct(constraint));
+
+  ++stats::solverQueries;
+  ++stats::queryCounterexamples;
+  ExprHandle stp_e = builder->construct(query.expr);
+  if (DebugDumpSTPQueries) {
+    char *buf;
+    unsigned long len;
+    vc_printQueryStateToBuffer(vc, stp_e, &buf, &len, false);
+    klee_warning("STP query:\n%.*s\n", (unsigned)len, buf);
+    free(buf);
+  }
+  bool success;
+  if (useForkedSTP) {
+    runStatusCode = runAndGetCexForked(vc, builder.get(), stp_e, objects,
+                                       values, hasSolution, timeout);
+    success = ((SOLVER_RUN_STATUS_SUCCESS_SOLVABLE == runStatusCode) ||
+               (SOLVER_RUN_STATUS_SUCCESS_UNSOLVABLE == runStatusCode));
+  } else {
+    runStatusCode =
+        runAndGetCex(vc, builder.get(), stp_e, objects, values, hasSolution);
+    success = true;
+  }
+  if (success) {
+    if (hasSolution)
+      ++stats::queriesInvalid;
+    else
+      ++stats::queriesValid;
+  }
+
+  vc_pop(vc);
+
+  return success;
+}
+
+bool STPSolverImpl::computeInitialValuesIncremental(
+    const Query &query, const std::vector<const Array *> &objects,
+    std::vector<std::vector<unsigned char>> &values, bool &hasSolution) {
   runStatusCode = SOLVER_RUN_STATUS_FAILURE;
   TimerStatIncrementer t(stats::queryTime);
 
   auto level = assertionStack.back();
   auto stack_it = level.begin();
   auto query_it = query.constraints.begin();
+
   // LCP between the assertion stack and the query constraints.
   while (stack_it != level.end() && query_it != query.constraints.end() && !(*stack_it)->compare(*(*query_it))) {
     ++stack_it;
@@ -402,6 +454,7 @@ bool STPSolverImpl::computeInitialValues(
   if (stack_it != level.end()) {
     klee_error("Old constraint set is not prefix of current one! Have you disabled optimiations?");
   }
+
   // Add the remaining query constraints.
   while (query_it != query.constraints.end()) {
     level.push_back(*query_it);
@@ -470,10 +523,18 @@ void STPSolver::setCoreSolverTimeout(time::Span timeout) {
 }
 
 void STPSolver::push() {
+  if (!UseIncrementalSolver) {
+    klee_error("Non incremental solver used in incremental mode");
+  }
+
   static_cast<STPSolverImpl *>(impl.get())->push();
 }
 
 void STPSolver::pop() {
+  if (!UseIncrementalSolver) {
+    klee_error("Non incremental solver used in incremental mode");
+  }
+
   static_cast<STPSolverImpl *>(impl.get())->pop();
 }
 

--- a/lib/Solver/STPSolver.h
+++ b/lib/Solver/STPSolver.h
@@ -29,6 +29,9 @@ public:
   /// format.
   std::string getConstraintLog(const Query &) override;
 
+  void push() override;
+  void pop() override;
+
   /// setCoreSolverTimeout - Set constraint solver timeout delay to the given
   /// value; 0
   /// is off.

--- a/lib/Solver/SolverCmdLine.cpp
+++ b/lib/Solver/SolverCmdLine.cpp
@@ -62,6 +62,11 @@ cl::opt<bool> DebugValidateSolver(
              "with the results of the core solver (default=false)"),
     cl::cat(SolvingCat));
 
+cl::opt<bool> UseIncrementalSolver(
+    "use-incremental", cl::init(false),
+    cl::desc("Use incremental solving (default=false)"),
+    cl::cat(SolvingCat));
+
 cl::opt<std::string> MinQueryTimeToLog(
     "min-query-time-to-log",
     cl::desc("Set time threshold for queries logged in files. "

--- a/lib/Solver/SolverCmdLine.cpp
+++ b/lib/Solver/SolverCmdLine.cpp
@@ -67,6 +67,11 @@ cl::opt<bool> UseIncrementalSolver(
     cl::desc("Use incremental solving (default=false)"),
     cl::cat(SolvingCat));
 
+cl::opt<bool> Verbose(
+    "verbose", cl::init(false),
+    cl::desc("Use verbose debugging statements"),
+    cl::cat(SolvingCat));
+
 cl::opt<std::string> MinQueryTimeToLog(
     "min-query-time-to-log",
     cl::desc("Set time threshold for queries logged in files. "

--- a/lib/Solver/Z3Solver.h
+++ b/lib/Solver/Z3Solver.h
@@ -24,6 +24,9 @@ public:
   /// \return A C-style string. The caller is responsible for freeing this.
   std::string getConstraintLog(const Query &) override;
 
+  void push() override;
+  void pop() override;
+
   /// setCoreSolverTimeout - Set constraint solver timeout delay to the given
   /// value; 0
   /// is off.


### PR DESCRIPTION
## Tasks

- [ ] Look into why the branch `addConstraint`s do not cause an error
- [ ] Consider a more memory-efficient implementation where constraint sets are NOT maintained for each state, and benchmark the memory improvement as this is a benefit of stack-based incrementality
- [ ] Transfer to LCP-PP where possible
- [ ] Remove verbose flag - it was for debugging purposes

## Notes

- Implementing this furthers our understanding of how well KLEE's practicalities and interactions with the core solver align with solver locality - the rearrangement of solver queries that we make here may transfer over to LCP-PP.
- When execution terminates early (due to a maximum time or fixed instructions being set - a common occurrence in real-world applications), we dump states, generating test cases for them according to the condition expressed within `shouldWriteTest` of `Executor.cpp`. This obviously queries the core solver for all such states, and, prior to this PR, iterates through all states in ascending order of ID. Thus, this does not occur in a DFS-way, and messes up the state of the solver. Instead of falling back on a non-stack based strategy, we make the following neat observation: simply reversing the order in which we iterate over states immediately fixes the issue - the `pop`s on termination are then in the precisely correct order!
- Let's compare this with what LCP-PP did prior to this - when we iterate through states in normal order (that is, DFS order) and keep the LCP of adjacent queries, we will pop down to the initial state's constraint set and then *relearn* - in contrast, by reversing, we will only be unlearning. 