### PR TITLE
LCP-PP Better Erase with CommonConstraints

### DIFF
--- a/include/klee/Expr/Constraints.h
+++ b/include/klee/Expr/Constraints.h
@@ -35,7 +35,6 @@ public:
   ConstraintSet() = default;
 
   void push_back(const ref<Expr> &e);
-  void pop_back();
 
   bool operator==(const ConstraintSet &b) const {
     return constraints == b.constraints;

--- a/include/klee/Solver/SolverStats.h
+++ b/include/klee/Solver/SolverStats.h
@@ -17,6 +17,7 @@ namespace stats {
 
   extern Statistic cexCacheTime;
   extern Statistic solverQueries;
+  extern Statistic commonConstraints;
   extern Statistic queries;
   extern Statistic queriesInvalid;
   extern Statistic queriesValid;

--- a/lib/Core/StatsTracker.cpp
+++ b/lib/Core/StatsTracker.cpp
@@ -450,6 +450,7 @@ void StatsTracker::writeStatsHeader() {
          << "MallocUsage INTEGER,"
          << "Queries INTEGER,"
          << "SolverQueries INTEGER,"
+         << "CommonConstraints INTEGER,"
          << "NumQueryConstructs INTEGER,"
          << "WallTime REAL,"
          << "CoveredInstructions INTEGER,"
@@ -497,6 +498,7 @@ void StatsTracker::writeStatsHeader() {
          << "MallocUsage,"
          << "Queries,"
          << "SolverQueries,"
+         << "CommonConstraints,"
          << "NumQueryConstructs,"
          << "WallTime,"
          << "CoveredInstructions,"
@@ -524,6 +526,7 @@ void StatsTracker::writeStatsHeader() {
   #undef TCLASS
   #define TCLASS(Name, I) << "?,"
   insert << " VALUES ("
+         << "?,"
          << "?,"
          << "?,"
          << "?,"
@@ -580,6 +583,7 @@ void StatsTracker::writeStatsLine() {
   sqlite3_bind_int64(insertStmt, arg++, util::GetTotalMallocUsage() + executor.memory->getUsedDeterministicSize());
   sqlite3_bind_int64(insertStmt, arg++, stats::queries);
   sqlite3_bind_int64(insertStmt, arg++, stats::solverQueries);
+  sqlite3_bind_int64(insertStmt, arg++, stats::commonConstraints);
   sqlite3_bind_int64(insertStmt, arg++, stats::queryConstructs);
   sqlite3_bind_int64(insertStmt, arg++, elapsed().toMicroseconds());
   sqlite3_bind_int64(insertStmt, arg++, stats::coveredInstructions);

--- a/lib/Expr/Constraints.cpp
+++ b/lib/Expr/Constraints.cpp
@@ -176,5 +176,3 @@ klee::ConstraintSet::constraint_iterator ConstraintSet::end() const {
 size_t ConstraintSet::size() const noexcept { return constraints.size(); }
 
 void ConstraintSet::push_back(const ref<Expr> &e) { constraints.push_back(e); }
-
-void ConstraintSet::pop_back() { constraints.pop_back(); }

--- a/lib/Solver/SolverStats.cpp
+++ b/lib/Solver/SolverStats.cpp
@@ -13,6 +13,7 @@ using namespace klee;
 
 Statistic stats::cexCacheTime("CexCacheTime", "CCtime");
 Statistic stats::solverQueries("SolverQueries", "SQ");
+Statistic stats::commonConstraints("CommonConstraints", "CC");
 Statistic stats::queries("Queries", "Q");
 Statistic stats::queriesInvalid("QueriesInvalid", "Qiv");
 Statistic stats::queriesValid("QueriesValid", "Qv");

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -258,6 +258,7 @@ bool Z3SolverImpl::internalRunSolver(
   while (stack_it != assertionStack.end() && query_it != query.constraints.end() && !(*stack_it)->compare(*(*query_it))) {
     ++stack_it;
     ++query_it;
+    ++stats::commonConstraints;
   }
 
   // LCP is computed; start the timer.

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -252,7 +252,6 @@ bool Z3SolverImpl::internalRunSolver(
   runStatusCode = SOLVER_RUN_STATUS_FAILURE;
   TimerStatIncrementer t(stats::queryTime);
 
-  // TODO: Reduce duplication with STPSolverImpl::computeInitialValues.
   auto stack_it = assertionStack.begin();
   auto query_it = query.constraints.begin();
   // LCP between the assertion stack and the query constraints.

--- a/lib/Solver/Z3Solver.cpp
+++ b/lib/Solver/Z3Solver.cpp
@@ -60,7 +60,7 @@ namespace klee {
 
 class Z3SolverImpl : public SolverImpl {
 private:
-  ConstraintSet assertionStack;
+  ConstraintSet::constraints_ty assertionStack;
   Z3_solver z3Solver;
   std::unique_ptr<Z3Builder> builder;
   time::Span timeout;
@@ -265,11 +265,9 @@ bool Z3SolverImpl::internalRunSolver(
   TimerStatIncrementer postLCPIncrementer(stats::postLCPTime);
 
   // Pop off extra constraints from stack.
-  size_t pops = std::distance(stack_it, assertionStack.end());
-  for (size_t i = 0; i < pops; ++i) {
-    Z3_solver_pop(builder->ctx, z3Solver, 1);
-    assertionStack.pop_back();
-  }
+  Z3_solver_pop(builder->ctx, z3Solver, std::distance(stack_it, assertionStack.end()));
+  assertionStack.erase(stack_it, assertionStack.end());
+
   // Add the remaining query constraints.
   while (query_it != query.constraints.end()) {
     Z3_solver_push(builder->ctx, z3Solver);

--- a/tools/klee-stats/klee-stats
+++ b/tools/klee-stats/klee-stats
@@ -107,6 +107,9 @@ Legend = [
         "SolverQueries",
     ),
     (
+        "CommonConstraints", "number of common constraints between consecutive queries", "CommonConstraints"
+    ),
+    (
         "SolverQueryConstructs",
         "number of query constructs for all queries send to the constraint solver",
         "NumQueryConstructs",


### PR DESCRIPTION
One might take issue with incrementing for Common Constraints, then measuring that time - so I'm hesitant to merge. But it's still useful for understanding why LCP-PP is not so bad compared to LCP-PP which should then be done separately.